### PR TITLE
Refresh placeholder illustrations with modern gradients

### DIFF
--- a/public/images/fallback.svg
+++ b/public/images/fallback.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="640" viewBox="0 0 960 640">
+  <defs>
+    <linearGradient id="fallback-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0b1120" />
+      <stop offset="50%" stop-color="#1e1b4b" />
+      <stop offset="100%" stop-color="#312e81" />
+    </linearGradient>
+    <linearGradient id="fallback-lines" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.5" />
+      <stop offset="100%" stop-color="#8b5cf6" stop-opacity="0.2" />
+    </linearGradient>
+    <linearGradient id="fallback-car" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#818cf8" />
+    </linearGradient>
+  </defs>
+  <rect width="960" height="640" fill="url(#fallback-bg)" />
+  <g opacity="0.25" stroke="url(#fallback-lines)" stroke-width="2">
+    <path d="M0 440 H960" />
+    <path d="M0 480 H960" />
+    <path d="M0 520 H960" />
+    <path d="M0 560 H960" />
+    <path d="M0 600 H960" />
+    <path d="M240 360 V640" />
+    <path d="M480 360 V640" />
+    <path d="M720 360 V640" />
+  </g>
+  <ellipse cx="480" cy="500" rx="320" ry="80" fill="#020617" opacity="0.7" />
+  <g transform="translate(160 220)" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M120 140 C210 40 390 0 560 40 C680 70 760 150 820 260" stroke="url(#fallback-car)" stroke-width="16" />
+    <path d="M160 220 H680 C740 220 780 260 780 320 C780 360 760 400 700 400 H200 C140 400 120 360 120 320 C120 260 160 220 160 220 Z" fill="#111827" stroke="#38bdf8" stroke-width="10" />
+    <path d="M220 240 Q480 120 740 240" fill="#1e3a8a" stroke="#93c5fd" stroke-width="8" />
+    <circle cx="260" cy="360" r="60" fill="#0f172a" stroke="#c7d2fe" stroke-width="12" />
+    <circle cx="260" cy="360" r="30" fill="#1f2937" />
+    <circle cx="660" cy="360" r="60" fill="#0f172a" stroke="#c7d2fe" stroke-width="12" />
+    <circle cx="660" cy="360" r="30" fill="#1f2937" />
+    <path d="M340 360 H580" stroke="#60a5fa" stroke-width="10" opacity="0.5" />
+  </g>
+  <g fill="#e0f2fe" font-family="'Poppins', sans-serif" font-size="32" opacity="0.6">
+    <text x="80" y="120">Ilustración no disponible</text>
+    <text x="80" y="160">Mostrando arte de reserva</text>
+  </g>
+</svg>

--- a/public/images/hero-background.svg
+++ b/public/images/hero-background.svg
@@ -1,0 +1,59 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="960" viewBox="0 0 1440 960">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#312e81" />
+    </linearGradient>
+    <radialGradient id="glow" cx="50%" cy="55%" r="60%">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.45" />
+      <stop offset="60%" stop-color="#1d4ed8" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#0f172a" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="car-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="40%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#4f46e5" />
+    </linearGradient>
+    <linearGradient id="car-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#bfdbfe" />
+      <stop offset="100%" stop-color="#1e3a8a" />
+    </linearGradient>
+    <linearGradient id="grid" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.25" />
+      <stop offset="100%" stop-color="#38bdf8" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="960" fill="url(#bg)" />
+  <rect width="1440" height="960" fill="url(#glow)" />
+  <g opacity="0.15" stroke="url(#grid)" stroke-width="1">
+    <path d="M0 680 H1440" />
+    <path d="M0 720 H1440" />
+    <path d="M0 760 H1440" />
+    <path d="M0 800 H1440" />
+    <path d="M0 840 H1440" />
+    <path d="M0 880 H1440" />
+    <path d="M240 520 V960" />
+    <path d="M480 520 V960" />
+    <path d="M720 520 V960" />
+    <path d="M960 520 V960" />
+    <path d="M1200 520 V960" />
+  </g>
+  <ellipse cx="720" cy="720" rx="420" ry="110" fill="#020617" opacity="0.8" />
+  <g transform="translate(200 360)">
+    <path d="M520 40 C650 40 760 96 820 200 L900 360 H120 L200 200 C260 96 370 40 500 40 Z" fill="url(#car-body)" />
+    <path d="M240 200 Q520 60 800 200 L840 280 H200 Z" fill="url(#car-glass)" stroke="#93c5fd" stroke-width="6" stroke-linejoin="round" />
+    <path d="M180 260 H860" stroke="#bfdbfe" stroke-width="8" stroke-linecap="round" opacity="0.6" />
+    <circle cx="260" cy="360" r="78" fill="#0f172a" stroke="#c7d2fe" stroke-width="14" />
+    <circle cx="260" cy="360" r="46" fill="#1f2937" />
+    <circle cx="780" cy="360" r="78" fill="#0f172a" stroke="#c7d2fe" stroke-width="14" />
+    <circle cx="780" cy="360" r="46" fill="#1f2937" />
+    <path d="M340 360 H700" stroke="#60a5fa" stroke-width="10" stroke-linecap="round" opacity="0.6" />
+    <path d="M480 120 H580" stroke="#bae6fd" stroke-width="12" stroke-linecap="round" opacity="0.8" />
+    <path d="M380 130 Q520 90 660 130" stroke="#c7d2fe" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+  </g>
+  <g opacity="0.6">
+    <path d="M280 260 L340 220" stroke="#60a5fa" stroke-width="6" stroke-linecap="round" />
+    <path d="M1160 260 L1100 220" stroke="#60a5fa" stroke-width="6" stroke-linecap="round" />
+  </g>
+</svg>

--- a/public/images/product-1.svg
+++ b/public/images/product-1.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="p1-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1e40af" />
+    </linearGradient>
+    <radialGradient id="p1-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.4" />
+      <stop offset="80%" stop-color="#1e3a8a" stop-opacity="0.05" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="p1-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#1d4ed8" />
+      <stop offset="50%" stop-color="#2563eb" />
+      <stop offset="100%" stop-color="#3b82f6" />
+    </linearGradient>
+    <linearGradient id="p1-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0.75" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#p1-bg)" />
+  <rect width="1200" height="800" fill="url(#p1-glow)" />
+  <g opacity="0.2" stroke="#38bdf8" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M400 400 V680" />
+    <path d="M600 400 V680" />
+    <path d="M800 400 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#010b19" opacity="0.8" />
+  <g transform="translate(200 260)">
+    <path d="M180 220 Q300 70 600 70 Q900 70 1020 220 L1080 340 H120 L180 220 Z" fill="url(#p1-body)" stroke="#60a5fa" stroke-width="8" stroke-linejoin="round" />
+    <path d="M240 240 Q600 40 960 240 L1000 320 H200 Z" fill="url(#p1-glass)" stroke="#bfdbfe" stroke-width="6" stroke-linejoin="round" />
+    <path d="M220 320 H980" stroke="#e0f2fe" stroke-width="10" stroke-linecap="round" opacity="0.5" />
+    <path d="M360 180 Q600 120 840 180" stroke="#bae6fd" stroke-width="8" stroke-linecap="round" opacity="0.6" />
+    <circle cx="320" cy="380" r="74" fill="#0f172a" stroke="#c7d2fe" stroke-width="14" />
+    <circle cx="320" cy="380" r="42" fill="#1e293b" />
+    <circle cx="880" cy="380" r="74" fill="#0f172a" stroke="#c7d2fe" stroke-width="14" />
+    <circle cx="880" cy="380" r="42" fill="#1e293b" />
+    <path d="M420 380 H780" stroke="#60a5fa" stroke-width="12" stroke-linecap="round" opacity="0.5" />
+  </g>
+  <g transform="translate(120 160)" fill="#cbd5f5" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Parabrisas delantero</text>
+    <path d="M0 40 H460" stroke="#3b82f6" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-2.svg
+++ b/public/images/product-2.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="p2-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="50%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#0f766e" />
+    </linearGradient>
+    <radialGradient id="p2-glow" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#34d399" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#0f766e" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#0f172a" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="p2-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#0f766e" />
+      <stop offset="50%" stop-color="#14b8a6" />
+      <stop offset="100%" stop-color="#2dd4bf" />
+    </linearGradient>
+    <linearGradient id="p2-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ecfeff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#5eead4" stop-opacity="0.7" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#p2-bg)" />
+  <rect width="1200" height="800" fill="url(#p2-glow)" />
+  <g opacity="0.2" stroke="#2dd4bf" stroke-width="2">
+    <path d="M120 600 H1080" />
+    <path d="M120 560 H1080" />
+    <path d="M120 520 H1080" />
+    <path d="M120 480 H1080" />
+    <path d="M360 420 V660" />
+    <path d="M600 420 V660" />
+    <path d="M840 420 V660" />
+  </g>
+  <ellipse cx="600" cy="620" rx="360" ry="90" fill="#0b1120" opacity="0.8" />
+  <g transform="translate(140 260)">
+    <path d="M240 320 L960 320 L1020 440 L180 440 Z" fill="#0f172a" stroke="#2dd4bf" stroke-width="10" stroke-linejoin="round" />
+    <path d="M220 220 C320 100 480 40 600 40 C720 40 880 100 980 220 L1040 320 H160 Z" fill="url(#p2-body)" />
+    <path d="M260 240 Q600 80 940 240 L980 300 H220 Z" fill="url(#p2-glass)" stroke="#a7f3d0" stroke-width="8" stroke-linejoin="round" />
+    <path d="M320 300 H880" stroke="#99f6e4" stroke-width="10" stroke-linecap="round" opacity="0.5" />
+    <path d="M360 260 Q600 160 840 260" stroke="#ccfbf1" stroke-width="8" stroke-linecap="round" opacity="0.5" />
+    <rect x="400" y="340" width="400" height="60" rx="20" fill="#0f172a" stroke="#14b8a6" stroke-width="6" opacity="0.7" />
+  </g>
+  <g transform="translate(140 160)" fill="#d1fae5" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Luneta trasera SUV</text>
+    <path d="M0 40 H520" stroke="#2dd4bf" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-3.svg
+++ b/public/images/product-3.svg
@@ -1,0 +1,47 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="p3-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0b1120" />
+      <stop offset="50%" stop-color="#1f2937" />
+      <stop offset="100%" stop-color="#7c3aed" />
+    </linearGradient>
+    <radialGradient id="p3-glow" cx="55%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#a855f7" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#312e81" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="p3-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#7c3aed" />
+      <stop offset="50%" stop-color="#8b5cf6" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+    <linearGradient id="p3-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ede9fe" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#c4b5fd" stop-opacity="0.7" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#p3-bg)" />
+  <rect width="1200" height="800" fill="url(#p3-glow)" />
+  <g opacity="0.2" stroke="#c4b5fd" stroke-width="2">
+    <path d="M140 620 H1060" />
+    <path d="M140 580 H1060" />
+    <path d="M140 540 H1060" />
+    <path d="M140 500 H1060" />
+    <path d="M320 420 V680" />
+    <path d="M520 420 V680" />
+    <path d="M720 420 V680" />
+    <path d="M920 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#020617" opacity="0.8" />
+  <g transform="translate(140 260)">
+    <path d="M160 340 L960 280 C1040 270 1080 320 1080 360 C1080 400 1040 450 960 460 L160 520 C120 520 80 480 80 420 C80 360 120 320 160 340 Z" fill="#1e1b4b" stroke="#a855f7" stroke-width="10" stroke-linejoin="round" />
+    <path d="M200 360 Q520 200 960 260 C1000 270 1020 300 1020 340 C1020 380 1000 420 960 430 L220 500" fill="#0f172a" stroke="#f3e8ff" stroke-width="8" stroke-linejoin="round" />
+    <path d="M240 380 Q520 240 900 300 Q940 308 940 340 C940 380 920 410 880 420 L280 480" fill="url(#p3-glass)" stroke="#ddd6fe" stroke-width="8" />
+    <path d="M260 420 Q540 280 880 340" stroke="#ede9fe" stroke-width="6" stroke-linecap="round" opacity="0.6" />
+    <path d="M300 450 Q560 320 840 360" stroke="#c4b5fd" stroke-width="6" stroke-linecap="round" opacity="0.4" />
+  </g>
+  <g transform="translate(160 160)" fill="#ede9fe" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Ventana lateral pick-up</text>
+    <path d="M0 40 H560" stroke="#a855f7" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-4.svg
+++ b/public/images/product-4.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="p4-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#f59e0b" />
+    </linearGradient>
+    <radialGradient id="p4-glow" cx="55%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#fbbf24" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#f97316" stop-opacity="0.08" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="p4-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#f97316" />
+      <stop offset="50%" stop-color="#fb923c" />
+      <stop offset="100%" stop-color="#facc15" />
+    </linearGradient>
+    <linearGradient id="p4-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fff7ed" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#fed7aa" stop-opacity="0.7" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#p4-bg)" />
+  <rect width="1200" height="800" fill="url(#p4-glow)" />
+  <g opacity="0.2" stroke="#fbbf24" stroke-width="2">
+    <path d="M120 620 H1080" />
+    <path d="M120 580 H1080" />
+    <path d="M120 540 H1080" />
+    <path d="M120 500 H1080" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#0b1120" opacity="0.8" />
+  <g transform="translate(220 200)">
+    <rect x="100" y="80" width="560" height="360" rx="180" fill="url(#p4-body)" stroke="#fde68a" stroke-width="12" />
+    <rect x="220" y="160" width="320" height="200" rx="80" fill="#0f172a" stroke="#fde68a" stroke-width="10" />
+    <rect x="240" y="180" width="280" height="160" rx="70" fill="url(#p4-glass)" stroke="#fef3c7" stroke-width="8" />
+    <path d="M260 220 H500" stroke="#fde68a" stroke-width="8" stroke-linecap="round" opacity="0.6" />
+    <path d="M260 260 H500" stroke="#fef08a" stroke-width="6" stroke-linecap="round" opacity="0.4" />
+    <path d="M260 300 H500" stroke="#fcd34d" stroke-width="6" stroke-linecap="round" opacity="0.3" />
+    <path d="M620 200 Q780 220 860 320" stroke="#fbbf24" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+    <path d="M620 260 Q760 300 820 380" stroke="#f59e0b" stroke-width="10" stroke-linecap="round" opacity="0.4" />
+    <path d="M620 320 Q720 360 760 420" stroke="#fb923c" stroke-width="8" stroke-linecap="round" opacity="0.3" />
+  </g>
+  <g transform="translate(160 160)" fill="#fef3c7" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Panel techo solar</text>
+    <path d="M0 40 H460" stroke="#fbbf24" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-5.svg
+++ b/public/images/product-5.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="p5-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#dc2626" />
+    </linearGradient>
+    <radialGradient id="p5-glow" cx="55%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#f87171" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#b91c1c" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="p5-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#ef4444" />
+      <stop offset="50%" stop-color="#f97316" />
+      <stop offset="100%" stop-color="#fb7185" />
+    </linearGradient>
+    <linearGradient id="p5-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f8fafc" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#fca5a5" stop-opacity="0.75" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#p5-bg)" />
+  <rect width="1200" height="800" fill="url(#p5-glow)" />
+  <g opacity="0.2" stroke="#fb7185" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#0f172a" opacity="0.85" />
+  <g transform="translate(200 240)">
+    <path d="M160 260 Q320 40 600 40 Q880 40 1040 260 L1080 360 H120 Z" fill="url(#p5-body)" stroke="#f87171" stroke-width="12" stroke-linejoin="round" />
+    <path d="M220 260 Q600 80 980 260 L1000 320 H200 Z" fill="url(#p5-glass)" stroke="#fecaca" stroke-width="8" stroke-linejoin="round" />
+    <path d="M240 320 H960" stroke="#fee2e2" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+    <path d="M360 200 Q600 140 840 200" stroke="#fecaca" stroke-width="10" stroke-linecap="round" opacity="0.5" />
+    <path d="M320 360 Q600 300 880 360" stroke="#fda4af" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+    <circle cx="320" cy="400" r="76" fill="#111827" stroke="#fecaca" stroke-width="14" />
+    <circle cx="320" cy="400" r="40" fill="#1f2937" />
+    <circle cx="880" cy="400" r="76" fill="#111827" stroke="#fecaca" stroke-width="14" />
+    <circle cx="880" cy="400" r="40" fill="#1f2937" />
+    <path d="M420 400 H780" stroke="#f87171" stroke-width="12" stroke-linecap="round" opacity="0.5" />
+  </g>
+  <g transform="translate(160 160)" fill="#fee2e2" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Parabrisas deportivo</text>
+    <path d="M0 40 H520" stroke="#fb7185" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-6.svg
+++ b/public/images/product-6.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="p6-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+    <radialGradient id="p6-glow" cx="55%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#0ea5e9" stop-opacity="0.08" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="p6-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#0ea5e9" />
+      <stop offset="50%" stop-color="#06b6d4" />
+      <stop offset="100%" stop-color="#22d3ee" />
+    </linearGradient>
+    <linearGradient id="p6-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#f0f9ff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#bae6fd" stop-opacity="0.75" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#p6-bg)" />
+  <rect width="1200" height="800" fill="url(#p6-glow)" />
+  <g opacity="0.2" stroke="#38bdf8" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#010b19" opacity="0.85" />
+  <g transform="translate(220 260)">
+    <path d="M160 260 C160 180 220 120 320 120 H760 C860 120 940 200 940 300 C940 380 880 460 800 480 L360 560 C260 580 160 500 160 400 Z" fill="#0f172a" stroke="#38bdf8" stroke-width="12" stroke-linejoin="round" />
+    <path d="M220 280 C220 220 280 170 360 170 H700 C780 170 840 230 840 300 C840 360 800 420 740 440 L360 520 C280 540 220 480 220 400 Z" fill="url(#p6-body)" />
+    <path d="M260 300 C260 250 300 220 360 220 H660 C720 220 760 260 760 310 C760 360 720 400 660 420 L360 500 C300 520 260 470 260 420 Z" fill="url(#p6-glass)" stroke="#e0f2fe" stroke-width="8" />
+    <path d="M320 320 L640 320" stroke="#bae6fd" stroke-width="8" stroke-linecap="round" opacity="0.6" />
+    <path d="M320 360 L620 360" stroke="#cffafe" stroke-width="6" stroke-linecap="round" opacity="0.5" />
+    <path d="M320 400 L560 400" stroke="#e0f2fe" stroke-width="6" stroke-linecap="round" opacity="0.4" />
+    <circle cx="420" cy="520" r="36" fill="#0f172a" stroke="#38bdf8" stroke-width="8" opacity="0.8" />
+    <path d="M760 200 Q860 220 900 300" stroke="#38bdf8" stroke-width="12" stroke-linecap="round" opacity="0.5" />
+    <path d="M760 240 Q840 260 870 320" stroke="#0ea5e9" stroke-width="10" stroke-linecap="round" opacity="0.35" />
+  </g>
+  <g transform="translate(160 160)" fill="#dbeafe" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Cristal espejo lateral</text>
+    <path d="M0 40 H560" stroke="#38bdf8" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-adas.svg
+++ b/public/images/product-adas.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="adas-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#4c1d95" />
+    </linearGradient>
+    <radialGradient id="adas-glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#1e3a8a" stop-opacity="0.08" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="adas-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#4f46e5" />
+      <stop offset="50%" stop-color="#6366f1" />
+      <stop offset="100%" stop-color="#818cf8" />
+    </linearGradient>
+    <linearGradient id="adas-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#eef2ff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#c7d2fe" stop-opacity="0.75" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#adas-bg)" />
+  <rect width="1200" height="800" fill="url(#adas-glow)" />
+  <g opacity="0.2" stroke="#6366f1" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#010b19" opacity="0.85" />
+  <g transform="translate(180 240)">
+    <path d="M200 260 Q360 80 600 80 Q840 80 1000 260 L1040 340 H160 Z" fill="url(#adas-body)" stroke="#a5b4fc" stroke-width="10" stroke-linejoin="round" />
+    <path d="M260 260 Q600 100 940 260 L960 320 H240 Z" fill="url(#adas-glass)" stroke="#c7d2fe" stroke-width="8" stroke-linejoin="round" />
+    <path d="M280 320 H920" stroke="#e0e7ff" stroke-width="12" stroke-linecap="round" opacity="0.6" />
+    <path d="M360 200 Q600 150 840 200" stroke="#c7d2fe" stroke-width="10" stroke-linecap="round" opacity="0.4" />
+    <circle cx="320" cy="380" r="72" fill="#111827" stroke="#c7d2fe" stroke-width="14" />
+    <circle cx="320" cy="380" r="38" fill="#1f2937" />
+    <circle cx="880" cy="380" r="72" fill="#111827" stroke="#c7d2fe" stroke-width="14" />
+    <circle cx="880" cy="380" r="38" fill="#1f2937" />
+  </g>
+  <g transform="translate(180 260)" fill="none" stroke-linecap="round">
+    <path d="M880 220 C960 200 1040 240 1080 300" stroke="#6366f1" stroke-width="12" opacity="0.5" />
+    <path d="M880 200 C980 170 1090 220 1140 300" stroke="#a855f7" stroke-width="10" opacity="0.4" />
+    <path d="M880 180 C1000 140 1120 200 1180 300" stroke="#c084fc" stroke-width="8" opacity="0.3" />
+    <path d="M320 220 C240 200 160 240 120 300" stroke="#6366f1" stroke-width="12" opacity="0.5" />
+    <path d="M320 200 C220 170 110 220 60 300" stroke="#a855f7" stroke-width="10" opacity="0.4" />
+    <path d="M320 180 C200 140 80 200 20 300" stroke="#c084fc" stroke-width="8" opacity="0.3" />
+  </g>
+  <g transform="translate(160 160)" fill="#e0e7ff" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Calibración ADAS</text>
+    <path d="M0 40 H460" stroke="#6366f1" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-rain.svg
+++ b/public/images/product-rain.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="rain-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#2563eb" />
+    </linearGradient>
+    <radialGradient id="rain-glow" cx="50%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#60a5fa" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#1d4ed8" stop-opacity="0.08" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="rain-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#e0f2fe" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#60a5fa" stop-opacity="0.75" />
+    </linearGradient>
+    <linearGradient id="wiper" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#rain-bg)" />
+  <rect width="1200" height="800" fill="url(#rain-glow)" />
+  <g opacity="0.25" stroke="#60a5fa" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#010b19" opacity="0.85" />
+  <g transform="translate(200 220)">
+    <path d="M160 260 Q360 60 600 60 Q840 60 1040 260 L1080 340 H120 Z" fill="url(#rain-glass)" stroke="#bfdbfe" stroke-width="10" stroke-linejoin="round" />
+    <path d="M200 320 H1000" stroke="#e0f2fe" stroke-width="12" stroke-linecap="round" opacity="0.5" />
+    <path d="M280 200 Q600 140 920 200" stroke="#bae6fd" stroke-width="8" stroke-linecap="round" opacity="0.5" />
+    <path d="M240 360 Q600 300 960 360" stroke="#bfdbfe" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+    <g opacity="0.45" fill="none" stroke="#93c5fd" stroke-width="6" stroke-linecap="round">
+      <path d="M240 240 C280 200 320 200 360 230" />
+      <path d="M380 230 C420 190 460 190 500 220" />
+      <path d="M520 220 C560 180 600 180 640 210" />
+      <path d="M660 210 C700 170 740 170 780 200" />
+      <path d="M800 200 C840 160 880 160 920 190" />
+    </g>
+    <g fill="#38bdf8" opacity="0.7">
+      <ellipse cx="260" cy="260" rx="16" ry="24" />
+      <ellipse cx="420" cy="240" rx="14" ry="22" />
+      <ellipse cx="580" cy="230" rx="12" ry="20" />
+      <ellipse cx="720" cy="220" rx="14" ry="22" />
+      <ellipse cx="880" cy="230" rx="16" ry="24" />
+      <ellipse cx="340" cy="300" rx="12" ry="18" />
+      <ellipse cx="500" cy="290" rx="14" ry="20" />
+      <ellipse cx="660" cy="290" rx="12" ry="18" />
+      <ellipse cx="820" cy="300" rx="14" ry="20" />
+    </g>
+    <path d="M280 380 L820 200" stroke="url(#wiper)" stroke-width="26" stroke-linecap="round" />
+    <circle cx="280" cy="380" r="38" fill="#0f172a" stroke="#1f2937" stroke-width="10" />
+  </g>
+  <g transform="translate(160 160)" fill="#dbeafe" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Tratamiento hidrofóbico</text>
+    <path d="M0 40 H620" stroke="#60a5fa" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-repair.svg
+++ b/public/images/product-repair.svg
@@ -1,0 +1,58 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="repair-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#059669" />
+    </linearGradient>
+    <radialGradient id="repair-glow" cx="52%" cy="48%" r="60%">
+      <stop offset="0%" stop-color="#34d399" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#047857" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="repair-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ecfdf5" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#6ee7b7" stop-opacity="0.7" />
+    </linearGradient>
+    <linearGradient id="repair-tool" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#repair-bg)" />
+  <rect width="1200" height="800" fill="url(#repair-glow)" />
+  <g opacity="0.2" stroke="#34d399" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#010b19" opacity="0.85" />
+  <g transform="translate(180 220)">
+    <path d="M200 260 Q380 60 600 60 Q820 60 1000 260 L1040 340 H160 Z" fill="url(#repair-glass)" stroke="#6ee7b7" stroke-width="10" stroke-linejoin="round" />
+    <path d="M240 320 H960" stroke="#bbf7d0" stroke-width="12" stroke-linecap="round" opacity="0.5" />
+    <path d="M300 200 Q600 140 900 200" stroke="#a7f3d0" stroke-width="8" stroke-linecap="round" opacity="0.5" />
+    <path d="M260 360 Q600 300 940 360" stroke="#bbf7d0" stroke-width="8" stroke-linecap="round" opacity="0.4" />
+    <g transform="translate(420 180)">
+      <circle cx="180" cy="160" r="90" fill="rgba(15,23,42,0.9)" stroke="#34d399" stroke-width="12" />
+      <circle cx="180" cy="160" r="56" fill="#0f172a" stroke="#6ee7b7" stroke-width="8" />
+      <path d="M180 100 V220" stroke="#6ee7b7" stroke-width="8" stroke-linecap="round" />
+      <path d="M120 160 H240" stroke="#6ee7b7" stroke-width="8" stroke-linecap="round" />
+      <path d="M180 120 L220 160 L180 200 L140 160 Z" fill="rgba(110,231,183,0.2)" stroke="#bbf7d0" stroke-width="4" />
+      <circle cx="180" cy="160" r="18" fill="#34d399" />
+    </g>
+    <g transform="translate(280 340)">
+      <rect x="0" y="0" width="320" height="60" rx="30" fill="url(#repair-tool)" stroke="#34d399" stroke-width="6" />
+      <rect x="320" y="20" width="220" height="40" rx="20" fill="#0f172a" stroke="#34d399" stroke-width="6" />
+      <circle cx="360" cy="40" r="18" fill="#34d399" />
+      <circle cx="410" cy="40" r="14" fill="#34d399" opacity="0.7" />
+    </g>
+  </g>
+  <g transform="translate(160 160)" fill="#bbf7d0" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Reparación parabrisas</text>
+    <path d="M0 40 H580" stroke="#34d399" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/product-tint.svg
+++ b/public/images/product-tint.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="tint-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#db2777" />
+    </linearGradient>
+    <radialGradient id="tint-glow" cx="55%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#f472b6" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#be123c" stop-opacity="0.08" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="tint-body" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0%" stop-color="#9d174d" />
+      <stop offset="50%" stop-color="#db2777" />
+      <stop offset="100%" stop-color="#f472b6" />
+    </linearGradient>
+    <linearGradient id="tint-glass" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#fde7f3" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#f472b6" stop-opacity="0.5" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#tint-bg)" />
+  <rect width="1200" height="800" fill="url(#tint-glow)" />
+  <g opacity="0.2" stroke="#f472b6" stroke-width="2">
+    <path d="M160 620 H1040" />
+    <path d="M160 580 H1040" />
+    <path d="M160 540 H1040" />
+    <path d="M160 500 H1040" />
+    <path d="M360 420 V680" />
+    <path d="M600 420 V680" />
+    <path d="M840 420 V680" />
+  </g>
+  <ellipse cx="600" cy="640" rx="360" ry="90" fill="#111827" opacity="0.85" />
+  <g transform="translate(180 240)">
+    <path d="M160 320 C160 180 320 80 520 80 H760 C940 80 1080 200 1080 320 C1080 440 960 520 800 520 H320 C220 520 160 420 160 320 Z" fill="url(#tint-body)" stroke="#f472b6" stroke-width="12" stroke-linejoin="round" />
+    <path d="M220 320 C220 220 340 160 520 160 H760 C900 160 980 220 980 320 C980 420 900 460 760 460 H320 C260 460 220 400 220 320 Z" fill="#1f0a25" stroke="#fbcfe8" stroke-width="8" />
+    <path d="M260 320 C260 250 340 210 500 210 H720 C860 210 900 260 900 320 C900 380 860 420 720 420 H320 C280 420 260 360 260 320 Z" fill="url(#tint-glass)" stroke="#f9a8d4" stroke-width="8" />
+    <path d="M300 320 C300 280 340 250 480 250 H700 C820 250 820 280 820 320 C820 360 820 390 700 390 H340 C320 390 300 360 300 320 Z" fill="#2d0f36" opacity="0.7" />
+    <path d="M340 320 C340 300 360 280 460 280 H660 C740 280 740 300 740 320 C740 340 740 360 660 360 H360 C350 360 340 340 340 320 Z" fill="#431142" opacity="0.6" />
+    <g opacity="0.4" stroke="#f9a8d4" stroke-width="6" stroke-linecap="round">
+      <path d="M320 260 Q420 220 520 240" />
+      <path d="M520 240 Q640 220 760 260" />
+      <path d="M360 360 Q520 340 680 360" />
+    </g>
+  </g>
+  <g transform="translate(160 160)" fill="#fbcfe8" font-family="'Poppins', sans-serif" font-size="48">
+    <text>Lámina seguridad &amp; tintado</text>
+    <path d="M0 40 H680" stroke="#f472b6" stroke-width="4" />
+  </g>
+</svg>

--- a/public/images/quote-bg.svg
+++ b/public/images/quote-bg.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="800" viewBox="0 0 1200 800">
+  <defs>
+    <linearGradient id="quote-bg" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#020617" />
+      <stop offset="50%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#4338ca" />
+    </linearGradient>
+    <radialGradient id="quote-glow" cx="45%" cy="45%" r="60%">
+      <stop offset="0%" stop-color="#6366f1" stop-opacity="0.45" />
+      <stop offset="70%" stop-color="#312e81" stop-opacity="0.1" />
+      <stop offset="100%" stop-color="#020617" stop-opacity="0" />
+    </radialGradient>
+    <linearGradient id="quote-card" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#1f2937" />
+    </linearGradient>
+    <linearGradient id="quote-detail" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#a855f7" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="800" fill="url(#quote-bg)" />
+  <rect width="1200" height="800" fill="url(#quote-glow)" />
+  <g opacity="0.15" stroke="#6366f1" stroke-width="2">
+    <path d="M0 620 H1200" />
+    <path d="M0 580 H1200" />
+    <path d="M0 540 H1200" />
+    <path d="M0 500 H1200" />
+    <path d="M240 420 V760" />
+    <path d="M480 420 V760" />
+    <path d="M720 420 V760" />
+    <path d="M960 420 V760" />
+  </g>
+  <ellipse cx="600" cy="640" rx="420" ry="110" fill="#010b19" opacity="0.8" />
+  <g transform="translate(200 200)">
+    <rect x="40" y="80" width="920" height="440" rx="48" fill="url(#quote-card)" stroke="#6366f1" stroke-width="6" />
+    <rect x="120" y="160" width="360" height="120" rx="24" fill="#0f172a" stroke="#38bdf8" stroke-width="4" />
+    <rect x="520" y="160" width="360" height="120" rx="24" fill="#111827" stroke="#a855f7" stroke-width="4" />
+    <rect x="120" y="320" width="760" height="60" rx="16" fill="#1f2937" opacity="0.9" />
+    <rect x="120" y="400" width="520" height="60" rx="16" fill="#1f2937" opacity="0.7" />
+    <g transform="translate(160 210)" fill="#e0e7ff" font-family="'Poppins', sans-serif">
+      <text font-size="32">VIN: 1HGBH41JXMN109186</text>
+      <text y="60" font-size="28" opacity="0.7">Cliente: Maria López</text>
+    </g>
+    <g transform="translate(560 210)" fill="#c7d2fe" font-family="'Poppins', sans-serif" font-size="32">
+      <text>Subtotal</text>
+      <text y="60" font-size="48" fill="#38bdf8">$8,450</text>
+    </g>
+    <g transform="translate(160 360)" fill="#c7d2fe" font-family="'Poppins', sans-serif" font-size="26">
+      <text>Parabrisas templado - Instalación incluida</text>
+    </g>
+    <g transform="translate(160 440)" fill="#94a3b8" font-family="'Poppins', sans-serif" font-size="24">
+      <text>Fecha estimada: 18/04/2024 · Garantía 12 meses</text>
+    </g>
+    <path d="M120 520 H840" stroke="url(#quote-detail)" stroke-width="8" stroke-linecap="round" opacity="0.7" />
+  </g>
+</svg>

--- a/src/app/quote/page.tsx
+++ b/src/app/quote/page.tsx
@@ -71,7 +71,7 @@ export default function QuotePage() {
       `*Email:* ${values.email}`,
       values.phone ? `*Teléfono:* ${values.phone}` : '',
       `---`,
-      `*Vehículo:* ${values.vehicleMake} ${values.vehicleModel} (${values.year})`,
+      `*Vehículo:* ${values.vehicleMake} ${values.vehicleModel} (${values.vehicleYear})`,
       values.vin ? `*VIN:* ${values.vin}` : '',
       `*Cristal Solicitado:* ${values.glassType}`
     ];

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -4,8 +4,7 @@ import { PlaceHolderImages } from '@/lib/placeholder-images';
 const getImage = (id: string) => {
   const image = PlaceHolderImages.find((img) => img.id === id);
   if (!image) {
-    // Use a placeholder from a configured host
-    return { id: 'fallback', url: 'https://images.unsplash.com/photo-1552519507-da3b142c6e3d?q=80&w=2070&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D', hint: 'placeholder' };
+    return { id: 'fallback', url: '/images/fallback.svg', hint: 'imagen predeterminada' };
   }
   return { id: image.id, url: image.imageUrl, hint: image.imageHint };
 };

--- a/src/lib/placeholder-images.json
+++ b/src/lib/placeholder-images.json
@@ -2,74 +2,74 @@
   "placeholderImages": [
     {
       "id": "hero-background",
-      "description": "Un coche deportivo rojo sobre un fondo oscuro y dramático.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/red-car-hero.jpg",
-      "imageHint": "coche rojo"
+      "description": "Ilustración estilizada de un coche deportivo iluminado sobre un fondo oscuro.",
+      "imageUrl": "/images/hero-background.svg",
+      "imageHint": "coche deportivo"
     },
     {
       "id": "product-1",
-      "description": "Parabrisas delantero para un sedán.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/windshield.jpg",
+      "description": "Ilustración de un parabrisas delantero para un sedán.",
+      "imageUrl": "/images/product-1.svg",
       "imageHint": "parabrisas coche"
     },
     {
       "id": "product-2",
-      "description": "Luneta Trasera para un SUV.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/rear-window.jpg",
+      "description": "Ilustración de luneta trasera para un SUV.",
+      "imageUrl": "/images/product-2.svg",
       "imageHint": "ventana coche"
     },
     {
       "id": "product-3",
-      "description": "Ventana lateral para una camioneta.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/side-window.jpg",
+      "description": "Ilustración de ventana lateral para una camioneta.",
+      "imageUrl": "/images/product-3.svg",
       "imageHint": "ventana coche"
     },
     {
       "id": "product-4",
-      "description": "Panel de cristal para techo solar.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/sunroof.jpg",
+      "description": "Ilustración de panel de cristal para techo solar.",
+      "imageUrl": "/images/product-4.svg",
       "imageHint": "techo solar coche"
     },
     {
       "id": "product-5",
-      "description": "Parabrisas delantero para un coche deportivo.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/vin.jpg",
+      "description": "Ilustración de parabrisas delantero para un coche deportivo.",
+      "imageUrl": "/images/product-5.svg",
       "imageHint": "parabrisas coche"
     },
     {
       "id": "product-6",
-      "description": "Cristal de espejo lateral.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/side-mirror.jpg",
+      "description": "Ilustración de cristal para espejo lateral.",
+      "imageUrl": "/images/product-6.svg",
       "imageHint": "espejo coche"
     },
     {
       "id": "quote-bg",
-      "description": "Primer plano de la placa del número VIN de un coche.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/vin.jpg",
+      "description": "Ilustración abstracta de una placa VIN y presupuesto.",
+      "imageUrl": "/images/quote-bg.svg",
       "imageHint": "VIN coche"
     },
     {
       "id": "product-repair",
-      "description": "Un técnico reparando una pequeña grieta en un parabrisas.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/windshield-repair.jpg",
+      "description": "Ilustración de reparación de un parabrisas con herramienta especializada.",
+      "imageUrl": "/images/product-repair.svg",
       "imageHint": "reparación parabrisas"
     },
     {
       "id": "product-adas",
-      "description": "Un coche con gráficos superpuestos que muestran el funcionamiento del sistema ADAS.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/adas-calibration.jpg",
+      "description": "Ilustración de coche con ondas que representan un sistema ADAS calibrado.",
+      "imageUrl": "/images/product-adas.svg",
       "imageHint": "coche ADAS"
     },
     {
       "id": "product-tint",
-      "description": "Un coche con las lunas traseras tintadas en un tono oscuro.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/window-tint.jpg",
+      "description": "Ilustración de coche con lunas traseras tintadas.",
+      "imageUrl": "/images/product-tint.svg",
       "imageHint": "lunas tintadas"
     },
     {
       "id": "product-rain",
-      "description": "Gotas de agua resbalando por un parabrisas tratado.",
-      "imageUrl": "https://storage.googleapis.com/studiopaper-dev.appspot.com/projects/e-com-glass/img/rain-repellent.jpg",
+      "description": "Ilustración de gotas de agua sobre un parabrisas tratado.",
+      "imageUrl": "/images/product-rain.svg",
       "imageHint": "coche lluvia"
     }
   ]


### PR DESCRIPTION
## Summary
- redesign the hero and fallback illustrations with layered gradients, glows, and car silhouettes to better match the brand aesthetic
- replace every product placeholder asset with stylized vector scenes tailored to each service offering
- rebuild the quote background artwork to include a premium-looking estimate card with VIN and pricing details

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dd6ac660ac8333ad9f58e08f7612ad