### PR TITLE
Remove focus param when typing new product search

### DIFF
--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 
 import { useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { products } from "@/lib/data";
 import { ProductCard } from "@/components/product-card";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
 
 export default function ProductsPage() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [searchTerm, setSearchTerm] = useState("");
 
   const filteredProducts = products.filter(
@@ -32,7 +36,14 @@ export default function ProductsPage() {
             placeholder="Buscar servicios..."
             className="pl-10"
             value={searchTerm}
-            onChange={(e) => setSearchTerm(e.target.value)}
+            onChange={(e) => {
+              const nextValue = e.target.value;
+              const params = new URLSearchParams(searchParams.toString());
+              params.delete("focus");
+              const queryString = params.toString();
+              router.replace(queryString ? `${pathname}?${queryString}` : pathname);
+              setSearchTerm(nextValue);
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary
- remove the focus query parameter when the search input changes so the focused product is not reapplied
- preserve other search parameters when updating the URL and keep the UI search state in sync

## Testing
- not run (Next.js lint configuration prompt blocks non-interactive execution)


------
https://chatgpt.com/codex/tasks/task_e_68df8583fa64833385104c128515eb2a